### PR TITLE
Existing traj integration

### DIFF
--- a/adaptivemd/analysis/pyemma/_remote.py
+++ b/adaptivemd/analysis/pyemma/_remote.py
@@ -26,7 +26,6 @@
 
 def remote_analysis(
         trajectories,
-        traj_name='output.dcd',
         selection=None,
         features=None,
         topfile='input.pdb',
@@ -40,10 +39,7 @@ def remote_analysis(
 
     Parameters
     ----------
-    trajectories : Sized of `Trajectory`
-        a list of `Trajectory` objects
-    traj_name : str
-        name of the trajectory file with the trajectory directory given
+    trajectories : Trajectory file paths
     selection : str
         an atom subset selection string as used in mdtraj .select
     features : dict or list or None
@@ -122,8 +118,7 @@ def remote_analysis(
 
     print '#trajectories :', len(trajectories)
 
-    files = [os.path.join(t, traj_name) for t in trajectories]
-    inp = pyemma.coordinates.source(files, feat)
+    inp = pyemma.coordinates.source(trajectories, feat)
 
     tica_obj = pyemma.coordinates.tica(
         inp, lag=tica_lag, dim=tica_dim, kinetic_map=False)

--- a/adaptivemd/analysis/pyemma/emma.py
+++ b/adaptivemd/analysis/pyemma/emma.py
@@ -187,7 +187,7 @@ class PyEMMAAnalysis(Analysis):
 
         t.call(
             remote_analysis,
-            trajectories=trajs,
+            trajectories=traj_paths,
             selection=ty.selection,  # tell pyemma the subsets of atoms
             features=features,
             topfile=input_pdb,

--- a/adaptivemd/analysis/pyemma/emma.py
+++ b/adaptivemd/analysis/pyemma/emma.py
@@ -170,10 +170,18 @@ class PyEMMAAnalysis(Analysis):
                 # ups, one of the trajectories does not have the required type!
                 return
 
+        if len(set(traj.types[outtype].stride for traj in trajs)) > 1:
+            # using different strides in trajectories
+            return
+
+        if len(set(traj.types[outtype].selection for traj in trajs)) > 1:
+            # different selection strings among trajectories
+            return
+
         ty = trajs[0].types[outtype]
 
         traj_paths = []
-        for traj in trajectories:
+        for traj in trajs:
             traj_paths.append(os.path.join(traj.location, traj.types[outtype].filename))
 
 

--- a/adaptivemd/analysis/pyemma/emma.py
+++ b/adaptivemd/analysis/pyemma/emma.py
@@ -182,8 +182,7 @@ class PyEMMAAnalysis(Analysis):
 
         traj_paths = []
         for traj in trajs:
-            traj_paths.append(os.path.join(traj.location, traj.types[outtype].filename))
-
+            traj_paths.append(traj.file(traj.types[outtype].filename).path)
 
         t.call(
             remote_analysis,

--- a/adaptivemd/analysis/pyemma/emma.py
+++ b/adaptivemd/analysis/pyemma/emma.py
@@ -172,26 +172,14 @@ class PyEMMAAnalysis(Analysis):
 
         ty = trajs[0].types[outtype]
 
-
-        engines = []
+        traj_paths = []
         for traj in trajectories:
-            if traj.engine not in engines:
-                engines.append(traj.engine)
-        
-        if len(engines) > 1:
-            trajs = []
-            for traj in trajectories:
-                trajs.append(os.path.join(traj.location, traj.types[outtype].filename))
-            trajectory_file_name = ''
-        else:
-            trajs = list(trajectories)
-            trajectory_file_name = ty.filename
+            traj_paths.append(os.path.join(traj.location, traj.types[outtype].filename))
 
 
         t.call(
             remote_analysis,
             trajectories=trajs,
-            traj_name=trajectory_file_name,  # we need the filename in the traj folder
             selection=ty.selection,  # tell pyemma the subsets of atoms
             features=features,
             topfile=input_pdb,

--- a/adaptivemd/analysis/pyemma/emma.py
+++ b/adaptivemd/analysis/pyemma/emma.py
@@ -172,10 +172,26 @@ class PyEMMAAnalysis(Analysis):
 
         ty = trajs[0].types[outtype]
 
+
+        engines = []
+        for traj in trajectories:
+            if traj.engine not in engines:
+                engines.append(traj.engine)
+        
+        if len(engines) > 1:
+            trajs = []
+            for traj in trajectories:
+                trajs.append(os.path.join(traj.location, traj.types[outtype].filename))
+            trajectory_file_name = ''
+        else:
+            trajs = list(trajectories)
+            trajectory_file_name = ty.filename
+
+
         t.call(
             remote_analysis,
             trajectories=trajs,
-            traj_name=ty.filename,  # we need the filename in the traj folder
+            traj_name=trajectory_file_name,  # we need the filename in the traj folder
             selection=ty.selection,  # tell pyemma the subsets of atoms
             features=features,
             topfile=input_pdb,

--- a/adaptivemd/scheduler.py
+++ b/adaptivemd/scheduler.py
@@ -362,7 +362,7 @@ class Scheduler(object):
         path = path.replace('sandbox://', '../..')
 
         # the main remote shared FS
-        path = path.replace('shared://', '')
+        path = path.replace('shared://', '../../..')
         path = path.replace('worker://', '')
         path = path.replace('file://', '')
         # the specific project folder://

--- a/adaptivemd/scheduler.py
+++ b/adaptivemd/scheduler.py
@@ -362,7 +362,7 @@ class Scheduler(object):
         path = path.replace('sandbox://', '../..')
 
         # the main remote shared FS
-        path = path.replace('shared://', '../../..')
+        path = path.replace('shared://', '')
         path = path.replace('worker://', '')
         path = path.replace('file://', '')
         # the specific project folder://

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -10,3 +10,4 @@ Examples Notebooks
    examples/example4
    examples/example5
    examples/example6
+   examples/example7

--- a/docs/examples/example7.rst
+++ b/docs/examples/example7.rst
@@ -1,0 +1,6 @@
+.. _example7:
+
+Example 7 - Miscellaneous
+=========================
+
+.. notebook:: examples/tutorial/7_example_misc.ipynb

--- a/examples/tutorial/7_example_misc.ipynb
+++ b/examples/tutorial/7_example_misc.ipynb
@@ -1,0 +1,270 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "## Importing existing trajectory data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In many cases, some trajectory data already exists before running an adaptive simulation. It is thus most efficiently to import this data into the framework. This works in principle by creating `Trajectory` objects and adding them to the `Project`. Since all of the trajectory-related data however is stored in the `Engine` object that generated it, this needs to be created as well."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "### Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "import sys, os"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "from adaptivemd import Project"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "Let's open our `test` project by its name. If you completed the previous example this should all work out of the box."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "project = Project('tutorial')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "Open all connections to the `MongoDB` and `Session` so we can get started."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create an import `Engine`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from adaptivemd import Trajectory\n",
+    "import time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "pdb_file = File('file://init.pdb').named('initial_pdb').load()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Since it is not desired to expand the trajectories at this point, system and integrator files are not given. In principle, if compatible restart files are available, one could create a complete engine and expand existing trajectories."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import_engine = OpenMMEngine(pdb_file=pdb_file,\n",
+    "                             system_file=None,\n",
+    "                             integrator_file=None,\n",
+    "                             args=None\n",
+    "                             ).named('openmm-import')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, to use the same `Modeller` as for the trajectories generated with `AdaptiveMD`, we build compatible output types. This means, they should contain the original file names with the respective strides and be named accordly. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import_engine.add_output_type('master', 'old-file-name-full.dcd', \n",
+    "                              stride=stride_full)\n",
+    "import_engine.add_output_type('protein', 'old-file-name-protein.dcd', \n",
+    "                              stride=stride_prot, \n",
+    "                              selection='protein')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Initialize `Trajectory` objects\n",
+    "To add the actual file paths, `Trajectory` objects have to be initialized. \n",
+    "- `Trajectory` locations are folders, not files, and end with '/'.\n",
+    "- `frame` can be None if the initial frame is not known.\n",
+    "- `length` as defined by the engine time step, not by the output/save rate of an output type.\n",
+    "- `engine`: import engine defined above.\n",
+    "\n",
+    "The example below uses a list of trajectory folders to import, `existing_trajectory_paths`. The trajectory lengths are known and stored in `existing_trajectory_lengths`.\n",
+    "\n",
+    "The `created` variable has to be set a creation time in order to let the database know the trajectory already exists. In the example below, the (arbitrary) import time is used."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "trajs = []\n",
+    "for traj_path, traj_length in zip(existing_trajectory_paths, \n",
+    "                                  existing_trajectory_lengths):\n",
+    "    traj = Trajectory('shared://' + traj_path,\n",
+    "                      frame=None,\n",
+    "                      length=traj_length,\n",
+    "                      engine=import_engine)\n",
+    "    traj.created = time.time()\n",
+    "    trajs.append(traj)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Add the trajectories to the project"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "map(project.files.add, trajs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's check if the trajectories have been added:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "len(project.trajectories)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "project.close()"
+   ]
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "py27_mar17",
+   "language": "python",
+   "name": "py27_mar17"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/examples/tutorial/7_example_misc.ipynb
+++ b/examples/tutorial/7_example_misc.ipynb
@@ -12,7 +12,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "In many cases, some trajectory data already exists before running an adaptive simulation. It is thus most efficiently to import this data into the framework. This works in principle by creating `Trajectory` objects and adding them to the `Project`. Since all of the trajectory-related data however is stored in the `Engine` object that generated it, this needs to be created as well."
    ]
@@ -88,7 +91,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "### Create an import `Engine`"
    ]
@@ -97,7 +103,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -109,7 +117,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -118,7 +128,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "Since it is not desired to expand the trajectories at this point, system and integrator files are not given. In principle, if compatible restart files are available, one could create a complete engine and expand existing trajectories."
    ]
@@ -127,7 +140,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -140,7 +155,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "Now, to use the same `Modeller` as for the trajectories generated with `AdaptiveMD`, we build compatible output types. This means, they should contain the original file names with the respective strides and be named accordly. "
    ]
@@ -149,7 +167,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -162,7 +182,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## Initialize `Trajectory` objects\n",
     "To add the actual file paths, `Trajectory` objects have to be initialized. \n",
@@ -171,7 +194,7 @@
     "- `length` as defined by the engine time step, not by the output/save rate of an output type.\n",
     "- `engine`: import engine defined above.\n",
     "\n",
-    "The example below uses a list of trajectory folders to import, `existing_trajectory_paths`. The trajectory lengths are known and stored in `existing_trajectory_lengths`.\n",
+    "The example below uses a list of trajectory folders to import, `existing_trajectory_paths`. Note that when adding this path with the `shared://` prefix, it must be a relative path in the root shared cluster file system. For absolute paths, use `worker://` instead. The trajectory lengths are known and stored in `existing_trajectory_lengths`.\n",
     "\n",
     "The `created` variable has to be set a creation time in order to let the database know the trajectory already exists. In the example below, the (arbitrary) import time is used."
    ]
@@ -180,7 +203,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -197,7 +222,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "#### Add the trajectories to the project"
    ]
@@ -206,7 +234,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -215,7 +245,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "Let's check if the trajectories have been added:"
    ]
@@ -224,7 +257,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [


### PR DESCRIPTION
This is the documentation on how to add existing trajectories. It includes a few fixes that were necessary:

- For multiple engines in a pyemma analysis, file names have to be adjusted accordingly. This fix is a bit hacky.
- Paths with prefix `shared://`are now taken as absolute paths and have to be entered as such. @jhprinz is this compatible with what you were thinking of when introducing `shared://`? 