### PR TITLE
Fix execution plan trigger loop

### DIFF
--- a/adaptivemd/plan.py
+++ b/adaptivemd/plan.py
@@ -36,7 +36,7 @@ class ExecutionPlan(object):
 
     def _update_conditions(self):
         self._finish_conditions = filter(
-            lambda x: not x(), self._finish_conditions)
+            lambda x: not x, self._finish_conditions)
 
     def __call__(self, scheduler):
         if self._running:
@@ -54,9 +54,11 @@ class ExecutionPlan(object):
     def trigger(self, scheduler):
         if self:
             self._update_conditions()
-            while self._running and len(self._finish_conditions) == 0:
+            while self._running:
                 self(scheduler)
                 self._update_conditions()
+
+
 
     def __nonzero__(self):
         return self._running

--- a/adaptivemd/plan.py
+++ b/adaptivemd/plan.py
@@ -58,8 +58,6 @@ class ExecutionPlan(object):
                 self(scheduler)
                 self._update_conditions()
 
-
-
     def __nonzero__(self):
         return self._running
 

--- a/examples/tutorial/2_example_run.ipynb
+++ b/examples/tutorial/2_example_run.ipynb
@@ -33,7 +33,7 @@
    },
    "outputs": [],
    "source": [
-    "from adaptivemd import Project, Event, FunctionalEvent, Trajectory"
+    "from adaptivemd import Project, Trajectory"
    ]
   },
   {
@@ -1351,7 +1351,9 @@
     "collapsed": true
    },
    "outputs": [],
-   "source": []
+   "source": [
+    ""
+   ]
   }
  ],
  "metadata": {
@@ -1364,7 +1366,7 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 2.0
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
@@ -1375,5 +1377,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 0
 }


### PR DESCRIPTION
After #47, execution plans do not get properly executed and get stuck at the first `yield` of the used generator. The reason is that the condition of the trigger loop, `len(self._finish_conditions) == 0`, is not fulfilled except for the case that no job has been finished yet. 